### PR TITLE
feat: basic lxd server terraform of cluster nodes and persistent gha runner

### DIFF
--- a/lxd-server/.terraform.lock.hcl
+++ b/lxd-server/.terraform.lock.hcl
@@ -1,0 +1,24 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/terraform-lxd/lxd" {
+  version     = "2.6.2"
+  constraints = "2.6.2"
+  hashes = [
+    "h1:V/0EaQ11hIqkM8K0uXh/Rug/0TcgNRp//OcazPdRlSI=",
+    "zh:0b7a3ba79cced2abf17885c592e14a2f72a64f53f3ad5d57a77a06dacd74ee2d",
+    "zh:1bf8cbae5d1df5a3becf99529bd3e0b51adf35ae8bc364997da6ec4090dde804",
+    "zh:6a8001a82ad149f3183c188881d9d378c220cd5dfac3cb41d3de9d44835bee00",
+    "zh:729ff26c06d83aa358e4c9495270473f667336db440a0eb18d039df004212e31",
+    "zh:8e316381fe28085dcc1190248ba661dab763a21abf15b1f7b5c7b411547bd3b6",
+    "zh:8f674e113f6a5276733b0575323d7e10b554e2e63614fb6dfefe9ec1b1b003fe",
+    "zh:9150d04cd9f2f75439e79505943c812d4f9ad00511bf2f1b3ae15af066ba355c",
+    "zh:9cc815df6598fff253a3674b739e0ae9bfd19f1829b1bf69008b9b903740e580",
+    "zh:bb4bef2d5d4878ad56c817ac45ca33c5bb9cd748cc92da414a4e87017f0ab274",
+    "zh:be516269f46242138b41c0e400c4391c11abf44e90a3adce887709b5241f89b0",
+    "zh:d7bcb92c975b93489d53c872ce91a5d0a6c2cbcde77f71a78b9544176036e98e",
+    "zh:e027bfec20488e37123f3ebce01fd3aacf870d93a0f37c5f81b7d9a2b0693efd",
+    "zh:ed4ec79f8be0ebe03484fc0721e22edbf2d982928636a73708f746572d0b2e0c",
+    "zh:ff52506693b8e006db6ca1c3e1deec0b07eb178d88179ea37c1a5f441d1c4f0f",
+  ]
+}

--- a/lxd-server/locals.tf
+++ b/lxd-server/locals.tf
@@ -1,0 +1,4 @@
+locals {
+  remote = "lxd-server"
+  image  = "ubuntu:24.04"
+}

--- a/lxd-server/main.tf
+++ b/lxd-server/main.tf
@@ -1,0 +1,103 @@
+resource "lxd_instance" "master" {
+  remote = local.remote
+
+  name  = "master"
+  image = local.image
+  type  = "virtual-machine"
+
+  limits = {
+    memory = "4GiB"
+    cpu    = 2
+  }
+
+  device {
+    name = "eth-1"
+    type = "nic"
+    properties = {
+      "network" = lxd_network.physical.name
+    }
+  }
+}
+
+resource "lxd_instance" "worker" {
+  count  = 2
+  remote = local.remote
+
+  name  = "worker-${count.index}"
+  image = local.image
+  type  = "virtual-machine"
+
+  allow_restart = true
+
+  limits = {
+    memory = "2GiB"
+    cpu    = 2
+  }
+
+  device {
+    name = "eth-1"
+    type = "nic"
+    properties = {
+      "network" = lxd_network.physical.name
+    }
+  }
+}
+
+resource "lxd_instance" "runner" {
+  remote = local.remote
+
+  name  = "runner"
+  image = local.image
+  type  = "virtual-machine"
+
+  limits = {
+    memory = "2GiB"
+    cpu    = 2
+  }
+
+  device {
+    name = "eth-1"
+    type = "nic"
+    properties = {
+      "network" = lxd_network.physical.name
+    }
+  }
+}
+
+resource "lxd_project" "this" {
+  name        = "default"
+  description = "Default LXD project"
+  config = {
+    "features.networks"       = "true"
+    "features.networks.zones" = "true"
+  }
+}
+
+resource "lxd_profile" "this" {
+  name        = "default"
+  description = "Default LXD profile"
+  project     = lxd_project.this.name
+
+  device {
+    name = "eth0"
+    type = "nic"
+    properties = {
+      network = "default"
+    }
+  }
+
+  device {
+    name = "root"
+    type = "disk"
+    properties = {
+      path = "/"
+      pool = "local"
+    }
+  }
+}
+
+resource "lxd_network" "physical" {
+  project = lxd_project.this.name
+  name    = "physical"
+  type    = "macvlan"
+}

--- a/lxd-server/provider.tf
+++ b/lxd-server/provider.tf
@@ -1,0 +1,20 @@
+terraform {
+  required_providers {
+    lxd = {
+      source  = "terraform-lxd/lxd"
+      version = "2.6.2"
+    }
+  }
+}
+
+provider "lxd" {
+  generate_client_certificates = true
+  accept_remote_certificate    = true
+
+  remote {
+    name    = local.remote
+    address = var.lxd_server
+    token   = var.lxd_token
+    default = true
+  }
+}

--- a/lxd-server/variables.tf
+++ b/lxd-server/variables.tf
@@ -1,0 +1,10 @@
+variable "lxd_token" {
+  description = "Token for LXD server authentication"
+  type        = string
+  sensitive   = true
+}
+
+variable "lxd_server" {
+  description = "URL of the LXD server"
+  type        = string
+}


### PR DESCRIPTION
This pull request introduces Terraform configuration for provisioning LXD virtual machines and related infrastructure. The main changes establish a new LXD project, profile, and network, and define resources for master, worker, and runner VMs, along with provider and variable setup.

Infrastructure provisioning:

* Added resources in `main.tf` to create three types of LXD virtual machines (`master`, two `worker`, and `runner`), each with specific resource limits and network device configuration. Also added resources for the LXD project, default profile, and a physical macvlan network.
* Defined local values for remote server and image in `locals.tf` to simplify resource configuration.

Provider and authentication setup:

* Added provider configuration in `provider.tf` to use the LXD provider, including remote server authentication and certificate handling.
* Introduced variables in `variables.tf` for LXD server address and authentication token, with the token marked as sensitive.

Dependency management:

* Added a Terraform lock file (`.terraform.lock.hcl`) to specify and lock the LXD provider version and its hashes for reproducible builds.